### PR TITLE
[PXSOD-9480] Start service in foreground per API reqs

### DIFF
--- a/src/android/Print.java
+++ b/src/android/Print.java
@@ -743,7 +743,7 @@ public class Print extends CordovaPlugin implements ReceiveListener {
 			PackageInfo info = packageManager.getPackageInfo("com.zebra.printconnect", 0);
 			long versionCode = info.getLongVersionCode();
 			if (versionCode >= NEW_PRINT_CONNECT_VERSION) {
-				// requiresForeground = true;
+				requiresForeground = true;
 			}
 		} catch (PackageManager.NameNotFoundException e) {
 			callbackContext.error(e.getMessage());

--- a/src/android/Print.java
+++ b/src/android/Print.java
@@ -731,7 +731,6 @@ public class Print extends CordovaPlugin implements ReceiveListener {
 		final String zplString = args.getString(0);
 		byte[] passthroughBytes = null;
 		boolean requiresForeground = false;
-		long versionCode = 0;
 
 		try {
 			passthroughBytes = zplString.getBytes("UTF-8");


### PR DESCRIPTION
From https://developer.android.com/guide/components/services#StartingAService

> If your app targets API level 26 or higher, the system imposes restrictions on using or creating background services unless the app itself is in the foreground. If an app needs to create a foreground service, the app should call [startForegroundService()](https://developer.android.com/reference/android/content/Context#startForegroundService(android.content.Intent)). That method creates a background service, but the method signals to the system that the service will promote itself to the foreground. Once the service has been created, the service must call its [startForeground()](https://developer.android.com/reference/android/app/Service#startForeground(int,%20android.app.Notification)) method within five seconds.